### PR TITLE
Album

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -18,7 +18,7 @@
 
 .card-vinyl {
   width: 22rem;
-  height: 640px;
+  height: 570px;
 }
 
 .card-vinyl > img,
@@ -97,14 +97,13 @@
   text-align: center;
 }
 
-.card-vinyl {
-  width: 22rem;
-  height: 540px;
-}
+// .card-vinyl {
+//   width: 22rem;
+//   height: 540px;
+// }
 
 .card-vinyl-infos {
   padding: 8px 0;
-  // height:100%;
 }
 
 .home-card {

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -122,9 +122,9 @@
 
     <div id="album_trivia" class="card-vinyl m-3" style="font-size: 20px; padding:  12px; color: #5C527F;" align-items-center>
       <% if @album.album_name == "Live at Glastonbury" %>
-        <strong><%= "Formed: "%></strong><%= "London / Birmingham 2021" %><br>
-        <strong><%= "Record Label: "%></strong><%= "Le Wagon" %><br>
-        <strong><%= "Producers: "%></strong><%= "Rahul, Anne" %><br>
+        <strong><%= "Formed: "%></strong><%= "London / Birmingham 2021" %><br><br>
+        <strong><%= "Record Label: "%></strong><%= "Le Wagon" %><br><br>
+        <strong><%= "Producers: "%></strong><%= "Rahul, Anne" %><br><br>
         <strong><%= "Members: "%></strong><%= "Clare Amos, Gid Berridge, Liz Tobin" %><br>
 
       <% else %>
@@ -136,13 +136,13 @@
 
   <!-- Buttons -->
 
-  <div class="d-flex align-items center justify-content-center col-12 mb-3">
+<!--   <div class="d-flex align-items center justify-content-center col-12 mb-3">
     <div class="row justify-content-center">
       <div><%= link_to "Search for #{@album.album_name} on discogs", "https://www.discogs.com/search/?type=all&title=#{@album.album_name}&artist=#{@album.artist.artist_name}&format=vinyl", class: "btn btn-primary mr-2", target: :blank %></div>
       <div><%= link_to 'Find a record store', sellers_path, class: "btn btn-primary mr-2" %></div>
       <div><%= link_to 'Go back to albums', :back, class: "btn btn-info" %></div>
     </div>
-  </div>
+  </div> -->
 
 </div>
 

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -27,7 +27,7 @@
         "https://www.discogs.com/search/?type=all&title=#{@album.album_name}&artist=#{@album.artist.artist_name}&format=vinyl",
         class: "btn btn-primary mr-2", target: :blank %></div>
         <div><%= link_to 'Find a record store', sellers_path, class: "btn btn-primary mr-2" %></div>
-        <div><%= link_to '<i class="fas fa-backward"></i>'.html_safe, ("/artists?query=#{@album.artist.artist_name}&commit=Search"), class: "btn btn-info" %></div>
+        <div><%= link_to '<i class="fas fa-backward"></i> Rewind'.html_safe, ("/artists?query=#{@album.artist.artist_name}&commit=Search"), class: "btn btn-info" %></div>
       </div>
     </div>
 

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -123,7 +123,15 @@
       <!-- Album trivia -->
 
     <div id="album_trivia" class="card-vinyl m-3" style="font-size: 20px; padding:  12px; color: #5C527F;" align-items-center>
-     <p id="album_name" class="hidden"> <%= @album.album_name%> <span style="display: hidden"><%= @album.artist.artist_name %></span></p>
+      <% if @album.album_name == "Live at Glastonbury" %>
+        <strong><%= "Formed: "%></strong><%= "London / Birmingham 2021" %><br>
+        <strong><%= "Record Label: "%></strong><%= "Le Wagon" %><br>
+        <strong><%= "Producers: "%></strong><%= "Rahul, Anne" %><br>
+        <strong><%= "Members: "%></strong><%= "Clare Amos, Gid Berridge, Liz Tobin" %><br>
+
+      <% else %>
+        <p id="album_name" class="hidden"> <%= @album.album_name%> <span style="display: hidden"><%= @album.artist.artist_name %></span></p>
+      <% end %>
     </div>
 
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1061,7 +1061,7 @@ Album.create!(
   )
 
 Artist.create!(
-  artist_name: 'The Tracers of Vinyl ',
+  artist_name: 'The Tracers of Vinyl',
   band_members: ["Clare Amos", "Gid Berridge", "Liz Tobin"]
   )
 
@@ -1079,24 +1079,6 @@ Album.create!(
 "Move to the Algorithm", "Array of light", "Seven function army", "Lucy in the sky with Bootstrap" ]
   )
 
-Artist.create!(
-  artist_name: 'The Tracers of Vinyl ',
-  band_members: ["Clare Amos", "Gid Berridge", "Liz Tobin"]
-  )
-
-Album.create!(
-  album_name: "Born to Code",
-  year: '2021',
-  artwork_url: 'https://upload.wikimedia.org/wikipedia/en/9/94/Specials_uk_front.jpg',
-  producers: ["Rahul", "Anne"],
-  record_label: 'Le Wagon',
-  seller_id: Seller.all.sample.id,
-  genre: ['Ruby', 'HTML', 'CSS', 'Javascript'],
-  artist_id: Artist.last.id,
-  tracks: ["I love coding", "Did somebody say just code?", "Coding in the morning", "Coding at night",
-"Coding in the afternoon", "I can't get no (SQL)", "Does my back-end look big in this?",
-"Move to the Algorithm", "Array of light", "Seven function army", "Lucy in the sky with Bootstrap" ]
-  )
 
 puts "Albums created"
 puts "done"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1060,6 +1060,25 @@ Album.create!(
 "Move to the Algorithm", "Array of light", "Seven function army", "Lucy in the sky with Bootstrap" ]
   )
 
+Artist.create!(
+  artist_name: 'The Tracers of Vinyl ',
+  band_members: ["Clare Amos", "Gid Berridge", "Liz Tobin"]
+  )
+
+Album.create!(
+  album_name: "Born to Code",
+  year: '2021',
+  artwork_url: 'https://upload.wikimedia.org/wikipedia/en/9/94/Specials_uk_front.jpg',
+  producers: ["Rahul", "Anne"],
+  record_label: 'Le Wagon',
+  seller_id: Seller.all.sample.id,
+  genre: ['Ruby', 'HTML', 'CSS', 'Javascript'],
+  artist_id: Artist.last.id,
+  tracks: ["I love coding", "Did somebody say just code?", "Coding in the morning", "Coding at night",
+"Coding in the afternoon", "I can't get no (SQL)", "Does my back-end look big in this?",
+"Move to the Algorithm", "Array of light", "Seven function army", "Lucy in the sky with Bootstrap" ]
+  )
+
 puts "Albums created"
 puts "done"
 


### PR DESCRIPTION
I've done some very minor tweeks - 
Added some text to The Vinyl Tracers album. If you add it to favourites via the home page search then click on it you will get it as a featured album with track titles and some hard coded album info. If you want to add to this it is in Album Show under album trivia. It could probably do a sentence or two.
I've also changed the seed very slightly so the six degrees doesn't choose the same albums. I've taken out a few of the links so it is less random but hopefully unable to pick the same album twice. I'm pretty sure I've got every possible route so it can't do this but if you do find one let me know and I will tweek the links again. You will need to db:seed.